### PR TITLE
feat: support building protoc from source

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -30,10 +30,29 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d71b6127be86fdcfddb610f7182ac57211d4b18a3e9c82eb2d17662f2227ad6a"
 
 [[package]]
+name = "cc"
+version = "1.2.36"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5252b3d2648e5eedbc1a6f501e3c795e07025c1e93bbf8bbdd6eef7f447a6d54"
+dependencies = [
+ "find-msvc-tools",
+ "shlex",
+]
+
+[[package]]
 name = "cfg-if"
 version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2fd1289c04a9ea8cb22300a459a72a385d7c73d3259e2ed7dcb2af674838cfa9"
+
+[[package]]
+name = "cmake"
+version = "0.1.54"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e7caa3f9de89ddbe2c607f4101924c5abec803763ae9534e4f4d7d8f84aa81f0"
+dependencies = [
+ "cc",
+]
 
 [[package]]
 name = "either"
@@ -62,6 +81,12 @@ name = "fastrand"
 version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
+
+[[package]]
+name = "find-msvc-tools"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7fd99930f64d146689264c637b5af2f0233a933bef0d8570e2526bf9e083192d"
 
 [[package]]
 name = "fixedbitset"
@@ -138,6 +163,7 @@ dependencies = [
  "prost",
  "prost-build",
  "prost-types",
+ "protobuf-src",
 ]
 
 [[package]]
@@ -240,6 +266,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "protobuf-src"
+version = "2.1.1+27.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6217c3504da19b85a3a4b2e9a5183d635822d83507ba0986624b5c05b83bfc40"
+dependencies = [
+ "cmake",
+]
+
+[[package]]
 name = "quote"
 version = "1.0.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -295,6 +330,12 @@ dependencies = [
  "linux-raw-sys",
  "windows-sys",
 ]
+
+[[package]]
+name = "shlex"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
 
 [[package]]
 name = "syn"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,6 +19,9 @@ heck = "0.5.0"
 prost = "0.14.1"
 prost-build = "0.14.1"
 prost-types = "0.14.1"
+protobuf-src = { version = "2.1.1", optional = true }
+
 
 [features]
 default = []
+build-protoc = ["protobuf-src"] # Build `protoc` from source instead of relying on a system installation

--- a/build.rs
+++ b/build.rs
@@ -73,6 +73,11 @@ const PROTOS: &[&str] = &[
 ];
 
 fn main() -> Result<()> {
+    #[cfg(feature = "build-protoc")]
+    {
+        println!("build-protoc feature is enabled");
+        env::set_var("PROTOC", protobuf_src::protoc());
+    }
     let out_dir = PathBuf::from(env::var("OUT_DIR").expect("OUT_DIR not set"));
     println!("cargo:rerun-if-changed=proto");
 


### PR DESCRIPTION
This pull request adds support for building the `protoc` binary from source as an optional feature, improving build portability and flexibility. The main changes include introducing the `protobuf-src` dependency and a new `build-protoc` feature, along with conditional logic in `build.rs` to use the built `protoc` binary when the feature is enabled.

**Dependency and feature additions:**

* Added `protobuf-src` as an optional dependency in `Cargo.toml` to allow building `protoc` from source.
* Introduced the `build-protoc` feature in `Cargo.toml`, which enables building `protoc` from source rather than relying on a system installation.

**Build script enhancements:**

* Updated `build.rs` to check for the `build-protoc` feature and set the `PROTOC` environment variable to the path of the built `protoc` binary if enabled, improving build flexibility across different environments.